### PR TITLE
Fix reset momentum

### DIFF
--- a/StarterPlayer/StarterCharacterScripts/client/morphs.lua
+++ b/StarterPlayer/StarterCharacterScripts/client/morphs.lua
@@ -100,8 +100,6 @@ local function handleAvatarEvent(ev: mt.avatarEvent)
 
 		--note: among many other places, the fact that the user can arbitrarily send RUN_CANCEL by hitting z at any time makes this confusing!
 		avatarManipulation.ResetPhysicalAvatarMorphs(humanoid, character)
-		avatarManipulation.ResetMomentum(humanoid, character)
-		_annotate("reset momentum1")
 		activeRunSignModule = nil
 	elseif ev.eventType == mt.avatarEventTypes.RUN_START then
 		if activeRunSignModule then
@@ -112,8 +110,6 @@ local function handleAvatarEvent(ev: mt.avatarEvent)
 			activeRunSignModule.InformRunEnded()
 		end
 		activeRunSignModule = nil
-		avatarManipulation.ResetMomentum(humanoid, character)
-		_annotate("reset momentum")
 		if ev.details.relatedSignName == "Pulse" then
 			activeRunSignModule = pulseSign
 		elseif ev.details.relatedSignName == "Big" then
@@ -138,6 +134,15 @@ local function handleAvatarEvent(ev: mt.avatarEvent)
 			_annotate("Telling acitve module about floor.")
 			activeRunSignModule.InformSawFloorDuringRunFrom(ev.details.floorMaterial)
 		end
+	end
+
+	if 
+		ev.eventType == mt.avatarEventTypes.RUN_START
+		or ev.eventType == mt.avatarEventTypes.RUN_CANCEL
+		or ev.eventType == mt.avatarEventTypes.RUN_COMPLETE
+		or ev.eventType == mt.avatarEventTypes.RETOUCH_SIGN then
+	then
+		avatarManipulation.ResetAbnormalMomentum(humanoid, character)
 	end
 	debouncHandleAvatarEvent = false
 end

--- a/StarterPlayer/StarterCharacterScripts/client/morphs.lua
+++ b/StarterPlayer/StarterCharacterScripts/client/morphs.lua
@@ -140,7 +140,7 @@ local function handleAvatarEvent(ev: mt.avatarEvent)
 		ev.eventType == mt.avatarEventTypes.RUN_START
 		or ev.eventType == mt.avatarEventTypes.RUN_CANCEL
 		or ev.eventType == mt.avatarEventTypes.RUN_COMPLETE
-		or ev.eventType == mt.avatarEventTypes.RETOUCH_SIGN then
+		or ev.eventType == mt.avatarEventTypes.RETOUCH_SIGN
 	then
 		avatarManipulation.ResetAbnormalMomentum(humanoid, character)
 	end

--- a/StarterPlayer/StarterPlayerScripts/avatarManipulation.lua
+++ b/StarterPlayer/StarterPlayerScripts/avatarManipulation.lua
@@ -72,6 +72,32 @@ module.ResetMomentum = function(humanoid: Humanoid, character: Model)
 	resetMomentumDebounce = false
 end
 
+module.ResetAbnormalMomentum(humanoid: Humanoid, character: Model)
+	local rootPart = character:WaitForChild("HumanoidRootPart") :: BasePart
+	local state = humanoid:GetState()
+	
+	-- Cancel fling-like states
+	if
+		state == Enum.HumanoidStateType.FallingDown
+		or state == Enum.HumanoidStateType.Seated
+		or state == Enum.HumanoidStateType.PlatformStanding
+	then
+		humanoid:ChangeState(Enum.HumanoidStateType.Freefall)
+	end
+	
+	-- Cap horizontal velocity
+	local horizontalVelocity = rootPart.AssemblyLinearVelocity * Vector3.new(1, 0, 1)
+	
+	if horizontalVelocity.Magnitude > humanoid.WalkSpeed then
+		rootPart.AssemblyLinearVelocity = horizontalVelocity.Unit * humanoid.WalkSpeed + Vector3.new(0, rootPart.AssemblyLinearVelocity.Y, 0)
+	end
+	
+	-- Cap vertical velocity
+	if math.abs(rootPart.AssemblyLinearVelocity.Y) > 100 then
+		rootPart.AssemblyLinearVelocity = horizontalVelocity + Vector3.new(0, math.sign(rootPart.AssemblyLinearVelocity.Y) * 100, 0)
+	end
+end
+
 module.SetCharacterTransparency = function(player: Player, target: number)
 	_annotate("Player made transparent: " .. tostring(target))
 	local targetCharacter = player.Character


### PR DESCRIPTION
Fixes the issue of reseting momentum on sign hits feeling annoying for regular players by only reseting the excessive momentum instead of reseting all momentum.